### PR TITLE
Bump bundler and dragonfly versions to address vulnerabilities.

### DIFF
--- a/lib/paperdragon/version.rb
+++ b/lib/paperdragon/version.rb
@@ -1,3 +1,3 @@
 module Paperdragon
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end

--- a/paperdragon.gemspec
+++ b/paperdragon.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dragonfly", "~> 1.0.12"
+  spec.add_dependency "dragonfly", "~> 1.4.0"
   spec.add_dependency "uber"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.2.10"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
 end


### PR DESCRIPTION
Primarily intended to address https://github.com/smile-io/paperdragon/security/dependabot/paperdragon.gemspec/dragonfly/open, which is a remote code execution vulnerability.